### PR TITLE
revert to mongoose 4.5.10 fix replicaset issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "md5": "^2.2.0",
     "method-override": "^2.3.6",
     "morgan": "1.7.0",
-    "mongoose": "^4.6.1",
+    "mongoose": "4.5.10",
     "passport": "^0.2.0",
     "q": "^1.0.1",
     "querystring": "0.2.0",


### PR DESCRIPTION
fix for `MongoError: no primary found in replicaset.` in docker containers 
Automattic/mongoose/issues/4596